### PR TITLE
Fixing `toFloatChannelData()` conflict with base AudioKit

### DIFF
--- a/Demo/WaveformDemo/ContentView.swift
+++ b/Demo/WaveformDemo/ContentView.swift
@@ -8,7 +8,7 @@ class WaveformDemoModel: ObservableObject {
     var samples: SampleBuffer
 
     init(file: AVAudioFile) {
-        let stereo = file.toFloatChannelData()!
+        let stereo = file.floatChannelData()!
         samples = SampleBuffer(samples: stereo[0])
     }
 }

--- a/Sources/Waveform/AVAudio+FloatData.swift
+++ b/Sources/Waveform/AVAudio+FloatData.swift
@@ -54,7 +54,7 @@ extension AVAudioFile {
     }
 
     /// converts to Swift friendly Float array
-    public func toFloatChannelData() -> [[Float]]? {
+    public func floatChannelData() -> [[Float]]? {
         guard let pcmBuffer = toAVAudioPCMBuffer(),
               let data = pcmBuffer.toFloatChannelData() else { return nil }
         return data

--- a/Tests/WaveformTests/WaveformTests.swift
+++ b/Tests/WaveformTests/WaveformTests.swift
@@ -82,7 +82,7 @@ final class WaveformTests: XCTestCase {
 
         let file = try! AVAudioFile(forReading: url)
 
-        let stereo = file.toFloatChannelData()!
+        let stereo = file.floatChannelData()!
 
         await render(samples: stereo[0])
     }


### PR DESCRIPTION
If you are using `AudioKit` and `Waveform` together, the compiler will report an error of `Ambigious use of toFloatChannelData()` as both Waveform and AudioKit have an extension on `AVAudioFile` that do the same thing. I have replaced the name in Waveform's to `floatChannelData()` -- i'm not sure if this is the best approach as this will probably be a breaking change for folks but I also can't imagine not using waveform without AudioKit.