### PR TITLE
Sync updates

### DIFF
--- a/Sources/Waveform/Renderer.swift
+++ b/Sources/Waveform/Renderer.swift
@@ -143,7 +143,7 @@ class Renderer: NSObject, MTKViewDelegate {
         commandBuffer.commit()
     }
 
-    func set(samples: SampleBuffer, start: Int, length: Int) async {
+    func set(samples: SampleBuffer, start: Int, length: Int) {
         self.start = start
         self.length = length
         if samples === self.samples {

--- a/Sources/Waveform/Waveform.swift
+++ b/Sources/Waveform/Waveform.swift
@@ -59,12 +59,7 @@ public struct Waveform: NSViewRepresentable {
     public func updateNSView(_ nsView: NSViewType, context: Context) {
         let renderer = context.coordinator.renderer
         renderer.constants = constants
-        Task {
-            await renderer.set(samples: samples,
-                               start: start,
-                               length: length)
-            nsView.setNeedsDisplay(nsView.bounds)
-        }
+        renderer.set(samples: samples, start: start, length: length)
         nsView.setNeedsDisplay(nsView.bounds)
     }
 }
@@ -121,12 +116,7 @@ public struct Waveform: UIViewRepresentable {
     public func updateUIView(_ uiView: UIViewType, context: Context) {
         let renderer = context.coordinator.renderer
         renderer.constants = constants
-        Task {
-            await renderer.set(samples: samples,
-                               start: start,
-                               length: length)
-            uiView.setNeedsDisplay()
-        }
+        renderer.set(samples: samples, start: start, length: length)
         uiView.setNeedsDisplay()
     }
 }


### PR DESCRIPTION
Buffer updates are designed to be async, however the properties themselves are not isolated. The use of `async` keyword creates a suspension point and can change execution context (effectively updating from the thread pool/multiple threads):

![Screenshot 2024-09-27 at 08 22 23](https://github.com/user-attachments/assets/d299cc2b-076e-4ad9-a578-6889c335d210)

which is then clearly visible under Thread Sanitizer:

![Screenshot 2024-09-27 at 08 19 30](https://github.com/user-attachments/assets/d236e63f-7e48-4770-842b-148d303808e5)

The current solution is equivalent to main thread updates.
Otherwise, we'd need to block the main thread to swap them and then access synchronously inside `draw()`, which is probably not worth the effort.